### PR TITLE
only use Colum Name for dropped Group Name (#581)

### DIFF
--- a/plugins/slick.draggablegrouping.js
+++ b/plugins/slick.draggablegrouping.js
@@ -229,7 +229,8 @@
           if (e.id == columnid) {
             if (e.grouping != null && !$.isEmptyObject(e.grouping)) {
               var entry = $("<div id='" + _gridUid + e.id + "_entry' data-id='" + e.id + "' class='slick-dropped-grouping'>");
-              var groupText = $("<div style='display: inline-flex'>" + column.text() + "</div>");
+              var columnName = column.children('.slick-column-name').first();
+              var groupText = $("<div style='display: inline-flex'>" + (columnName.length ? columnName.text() : column.text()) + "</div>");
               groupText.appendTo(entry);
               var groupRemoveIcon = $("<div class='slick-groupby-remove'>&nbsp;</div>");
               if(options.deleteIconCssClass) groupRemoveIcon.addClass(options.deleteIconCssClass);


### PR DESCRIPTION
Now, if the dropped column header contains an element with class 'slick-column-name', only the text content of that element is used to populate the dropped grouping represenation. This prevents additional column header content from being displayed (like the order number in case of sorting by multiple columns).